### PR TITLE
Removed Parceler processing from library class

### DIFF
--- a/ParcelerTest/app/build.gradle
+++ b/ParcelerTest/app/build.gradle
@@ -19,13 +19,17 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    lintOptions {
+        abortOnError false
+    }
+
 }
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:21.0.2'
     compile "org.parceler:parceler-api:${parcelerVersion}"
-//    provided "org.parceler:parceler:${parcelerVersion}"
+    provided "org.parceler:parceler:${parcelerVersion}"
     compile project(':library')
 }
 @Field

--- a/ParcelerTest/app/src/main/java/test/com/parcelertest/MainActivity.java
+++ b/ParcelerTest/app/src/main/java/test/com/parcelertest/MainActivity.java
@@ -8,10 +8,11 @@ import android.view.Menu;
 import android.view.MenuItem;
 
 import org.parceler.Parcels;
+import org.parceler.ParcelClass;
 
 import test.com.library.BaseObject;
 
-
+@ParcelClass(BaseObject.class)
 public class MainActivity extends ActionBarActivity {
 
     @Override

--- a/ParcelerTest/library/build.gradle
+++ b/ParcelerTest/library/build.gradle
@@ -22,5 +22,4 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:21.0.2'
     compile 'org.parceler:parceler-api:0.2+'
-    provided 'org.parceler:parceler:0.2+'
 }


### PR DESCRIPTION
and included library base class via `@ParcelClass` (johncarl81/parceler#63)
